### PR TITLE
NSC-Dev-Expo-Site_36_add expo-linear-gradient

### DIFF
--- a/.expo/README.md
+++ b/.expo/README.md
@@ -1,0 +1,13 @@
+> Why do I have a folder named ".expo" in my project?
+
+The ".expo" folder is created when an Expo project is started using "expo start" command.
+
+> What do the files contain?
+
+- "devices.json": contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
+- "settings.json": contains the server configuration that is used to serve the application manifest.
+
+> Should I commit the ".expo" folder?
+
+No, you should not share the ".expo" folder. It does not contain any information that is relevant for other developers working on the project, it is specific to your machine.
+Upon project creation, the ".expo" folder is already added to your ".gitignore" file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",
         "expo": "~54.0.33",
+        "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-status-bar": "~3.0.9",
@@ -4776,6 +4777,17 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-linking": {
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
@@ -4895,6 +4907,7 @@
       "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.23.tgz",
       "integrity": "sha512-qCxVAiCrCyu0npky6azEZ6dJDMt77OmCzEbpF6RbUTlfkaCA417LvY14SBkk0xyGruSxy/7pvJOI6tuThaUVCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/metro-runtime": "^6.1.2",
         "@expo/schema-utils": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
     "expo": "~54.0.33",
+    "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-status-bar": "~3.0.9",

--- a/src/app/(pages)/test.tsx
+++ b/src/app/(pages)/test.tsx
@@ -1,0 +1,31 @@
+import { View, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function TestPage() {
+  return (
+    <View style={styles.container}>
+      <LinearGradient
+        // Colors for the gradient
+        colors={['#4c669f', '#3b5998', '#192f6a']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.gradient}
+    >
+      </LinearGradient>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#fff',
+    },
+    gradient: {
+        width: '80%', // Adjust size as needed
+        height: 200,
+        borderRadius: 15,
+    }
+});


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #36 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 Adds `expo-linear-gradient` libary from Expo.
  - 👀 Allows the creation of `LinearGradient` component to create color gradient for component background.


- **Changes:**
  - ✅ Added `"expo-linear-gradient": "~15.0.8"` to current package
  - ✅ Added `test.tsx` page to render a sample component
  - 📝 [Linear Gradient documentation](https://docs.expo.dev/versions/latest/sdk/linear-gradient/)


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>
  <!-- add GIFs/Screenshots/Videos/Diagrams here -->

<img width="1920" height="905" alt="image" src="https://github.com/user-attachments/assets/08e014de-2534-4ae0-8fe0-a44a50bf32cc" />

</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1:  clone the repo and switch to branch `feature/36_add_expo-linear-gradient`
   - Step 2: run `npm install`
   - Step 3: run `npm run start:web`
   - Step 4: navigate to `http://localhost:8081/test` to see the rendered component
2. **Expected Behavior:** The Page will render a box with a left - right gradient from blue to green
3. **Actual Behavior (if bug):** Component does not render


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #36 `).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [x] **Squash commits** and enable **auto-merge** if approved.

