### PR TITLE
NSC-Dev-Expo-Site_63_fix-navbar-stack-overlap

### DIFF
--- a/src/app/(pages)/_layout.tsx
+++ b/src/app/(pages)/_layout.tsx
@@ -4,34 +4,37 @@ import Navbar from "../../components/Navbar";
 
 export default function AppLayout() {
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, }}>
       <Navbar/>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen
-          name="index"
-          options={{
-            title: 'Home',
-          }}
-        />
-        <Stack.Screen
-          name="about"
-          options={{
-            title: 'About',
-          }}
-        />
-        <Stack.Screen
-          name="contact"
-          options={{
-            title: 'Contact',
-          }}
-        />
-        <Stack.Screen
-          name="student"
-          options={{
-            title: 'Student',
-          }}
-        />
-      </Stack>
+
+      <View style={{ flex: 1 }}>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen
+            name="index"
+            options={{
+              title: 'Home',
+            }}
+          />
+          <Stack.Screen
+            name="about"
+            options={{
+              title: 'About',
+            }}
+          />
+          <Stack.Screen
+            name="contact"
+            options={{
+              title: 'Contact',
+            }}
+          />
+          <Stack.Screen
+            name="student"
+            options={{
+              title: 'Student',
+            }}
+          />
+        </Stack>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** `#63`

- **Summary:**
  - 🔨 **What does this issue fix?**  
    Fixes a layout issue where screens rendered by Expo Router's `Stack`
    navigator could visually overlap the persistent `Navbar` component.

  - 👀 **What is the expected behavior?**  
    Routed screens should render **below the Navbar**, occupying the remaining
    vertical space of the application layout.

  - 🗨️ **Any relevant technical details?**  
    React Native layout is controlled using Flexbox. Previously, the `Stack`
    navigator was rendered directly beneath the `Navbar` without being
    constrained by a flex container. Because Expo Router screens may use
    internal positioning, this could cause screen content to expand into the
    Navbar's visual space.

    Wrapping the `Stack` inside a container with `flex: 1` explicitly assigns
    the remaining vertical space to routed screens and prevents overlap.

- **Changes:**
  - ✅ Wrapped the `Stack` navigator in `_layout.tsx` with a `View` container using `flex: 1`
  - ✅ Ensures routed screens render within the space below the persistent `Navbar`
  - 🔗 Linked to issue describing the layout behavior and proposed fix
  - 📝 No changes to routing, navigation behavior, or individual screen components


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>

--> Note that color styling is not being pushed with this PR and was added temporarily to demonstrate that containers fill available space:


<img width="545" height="1099" alt="Screenshot 2026-03-07 123141" src="https://github.com/user-attachments/assets/73fb204d-5207-4c2a-978e-6e30f927151b" />

<img width="545" height="1093" alt="Screenshot 2026-03-07 123158" src="https://github.com/user-attachments/assets/52d2d7f2-506b-4412-8f01-f7fea635f549" />

</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Run the application locally
   - Step 2: Navigate between available routes (`/`, `/about`, `/contact`, `/student`)
   - Step 3: Observe layout behavior relative to the Navbar

2. **Expected Behavior:**  
   Screen content renders **below the Navbar** and occupies the remaining
   vertical space of the layout.

3. **Actual Behavior (before fix):**  
   Screen content may visually overlap or encroach into the Navbar area due to
   the `Stack` navigator not being constrained by a flex container.


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #<issue-number>`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned.
- [x] **Squash commits** and enable **auto-merge** if approved.
