### PR TITLE
NSC-Dev-Expo-Site_46_add-storybook-docs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,11 +14,13 @@ Currently, we are using Stacks to generate dev page environment for developers t
 - Navigate to other pages in the `(pages)` directory by adding the name of the file after the root directory in the URL. Example: Student page will be `/student`, about will be `/about`, etc.
 Note: Review the video linked in the resource section to gain understanding how expo handles folder structure for routing. Always refer to [expo documentation](https://docs.expo.dev/) for in-depth knowledge in how Expo components work. 
 
+
 # Resources
 - [Review before implementing components or pages: Introduction to Expo Router Layout Files](https://youtu.be/Yh6Qlg2CYwQ?si=c5Zy0PBnwWYwzOtV)
 - [Figma Design](https://www.figma.com/design/nswMhBThzHDCqsR7F2HxbF/NSC-Dev-site-redesign-wireframes?node-id=73-1231&t=SbPUpY0Pq8fQwScA-1)
 - [React Native Component Library](https://reactnative.dev/docs/components-and-apis)
 - [CSS Reference](https://css-tricks.com/)
 - [Expo Router](https://docs.expo.dev/versions/latest/sdk/router/)
+- [Storybook Usage Guide](./STORYBOOK_GUIDE.md)
 
 This is a living document, so please feel free to add any useful tips or workflows

--- a/STORYBOOK_GUIDE.md
+++ b/STORYBOOK_GUIDE.md
@@ -1,0 +1,34 @@
+# Storybook Usage Guide
+This guide explains how to use Storybook in this project for developing and testing UI components in isolation.
+
+## What is Storybook?
+Storybook is a tool for building UI components and pages in isolation. It streamlines UI development, testing, and documentation.
+
+## Getting Started
+
+### 1. Install Dependencies
+If you haven't already, install project dependencies:
+```
+npm install
+```
+
+### 2. Running Storybook
+To start Storybook locally, run:
+```
+npm run storybook
+```
+
+Storybook will open in your browser at [http://localhost:6006](http://localhost:6006).
+
+## Adding Stories
+- Stories are located in the `src/stories/` directory.
+- To add a new component story, create a `.stories.tsx` file next to your component or in the stories directory.
+- Follow the existing story format for consistency.
+
+## Best Practices
+- Keep stories focused and simple.
+- Use stories to document different states and variations of your components.
+- Update stories when components change.
+
+## Resources
+- [Storybook Documentation](https://storybook.js.org/docs/react/get-started/introduction)


### PR DESCRIPTION
## Summary & Changes 
- **Resolves:** `#46

- **Summary:** (Briefly describe what this PR does)
- Adds a Storybook usage guide to the repository.
  - Developers can now easily find instructions for running and contributing to Storybook.
  - Linked the new guide in the main README under Resources.

- **Changes:**
 - Added STORYBOOK_GUIDE.md with setup and usage instructions.
  - Updated README.md to link to the new guide.
  - No breaking changes.

## How to Test 
1. **Steps to Reproduce:**
   - Step 1: Open STORYBOOK_GUIDE.md and README.md in the repo.
   - Step 2: Verify the Storybook guide is present and the README link works.
2. **Expected Behavior:**  
   - Storybook documentation is clear and accessible from the README.
3. **Actual Behavior (if bug):**  
   - N/A


## Checklist 
- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #46`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned.
- [x] **Squash commits** and enable **auto-merge** if approved.

