### PR TITLE
nsc-dev-expo-site_2_109_informational-section

### DIFF
--- a/src/components/InformationalComponent.tsx
+++ b/src/components/InformationalComponent.tsx
@@ -3,29 +3,30 @@ import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 type InformationalComponentProps = {
+  title: string;
+  iconName: React.ComponentProps<typeof MaterialIcons>['name'];
+  textSections: string[];
   onPress?: () => void;
 };
 
 export default function InformationalComponent({
+  title,
+  iconName,
+  textSections,
   onPress,
 }: InformationalComponentProps) {
   return (
     <View style={styles.sectionContainer}>
-      <Text style={styles.heading}>The Design Process</Text>
+      <Text style={styles.heading}>{title}</Text>
 
       <MaterialIcons
-        name="design-services"
+        name={iconName}
         size={54}
         color="#CDCDCD"
         style={styles.icon}
       />
 
-      <Text style={styles.bodyText}>
-        Find out how the App Development program do for you.
-        {'\n'}
-        {'\n'}
-        Grow your business or non-profit for free.
-      </Text>
+      <Text style={styles.bodyText}>{textSections.join('\n\n')}</Text>
 
       <Pressable
         accessibilityRole="button"

--- a/src/components/InformationalComponent.tsx
+++ b/src/components/InformationalComponent.tsx
@@ -1,174 +1,112 @@
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { View, Text, StyleSheet, ScrollView } from "react-native";
+type InformationalComponentProps = {
+  onPress?: () => void;
+};
 
+export default function InformationalComponent({
+  onPress,
+}: InformationalComponentProps) {
+  return (
+    <View style={styles.sectionContainer}>
+      <Text style={styles.heading}>The Design Process</Text>
 
-function TechItem({ name }: { name: string }) {
-   return (
+      <MaterialIcons
+        name="design-services"
+        size={54}
+        color="#CDCDCD"
+        style={styles.icon}
+      />
 
-      <View style={styles.techItem}>
-         <Text style={styles.toolLable}>Tool Icon</Text>
-         <Text style={styles.toolName}>{name}</Text>
+      <Text style={styles.bodyText}>
+        Find out how the App Development program do for you.
+        {'\n'}
+        {'\n'}
+        Grow your business or non-profit for free.
+      </Text>
 
-      </View>
-
-
-   );
-
+      <Pressable
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+      >
+        <Text style={styles.buttonLabel}>See more details</Text>
+        <MaterialIcons
+          name="keyboard-double-arrow-right"
+          size={22}
+          color="#FDFDFD"
+        />
+      </Pressable>
+    </View>
+  );
 }
-
-export default function InformationalComponent() {
-
-   return (
-      <ScrollView>
-
-         <View style={styles.container}>
-
-            <Text style={styles.title}>Learn What you Want</Text>
-            <Text style={styles.description}>In this program you will learn multiple languages and tools that you will have under your belt.
-               Afterwards, you can choose what you really want to pursue. With your practicum program you will
-               learn and strengthen your desired skills by building real applications to use in the real world.
-            </Text>
-
-            <View style={styles.grid}>
-               <TechItem name={"Java\nScript"} />
-               <TechItem name={"Figma"} />
-               <TechItem name={"SQL"} />
-               <TechItem name={"Git\nHub"} />
-               <TechItem name={"Mongo\nDB"} />
-               <TechItem name={"Type\nScript"} />
-
-            </View>
-
-
-            <Text style={styles.subtitle}> Pursue your passions</Text>
-            <Text style={styles.paragraph}>Not interested in the real world projects with clients.
-               Then you can build your own passion project. You will have a academic
-               support and faculty to aid you In learning the necessary skills in building and expanding your skil set.
-               Build what you are passionate about.</Text>
-
-            <View style={styles.imageBox}>
-               <Text>marketing image</Text>
-
-
-            </View>
-
-         </View>
-      </ScrollView>
-   );
-
-}
-
-
 
 const styles = StyleSheet.create({
-   container: {
-      paddingHorizontal: 20,
-      paddingVertical: 30,
-      backgroundColor: "white",
-      width: 390,
-      alignSelf: "center",
-
-   },
-
-
-   description: {
-      fontSize: 16,
-      lineHeight: 24,
-      marginBottom: 24,
-
-   },
-
-   sectionItem: {
-      fontSize: 18,
-      fontWeight: "bold",
-      marginBottom: 8,
-
-
-   },
-
-
-
-
-   title: {
-      fontSize: 24,
-      fontWeight: "bold",
-      marginBottom: 12,
-
-   },
-
-   subtitle: {
-      fontSize: 24,
-      fontWeight: "bold",
-      marginTop: 25,
-      marginBottom: 12,
-
-
-   },
-
-   paragraph: {
-      fontSize: 14,
-      lineHeight: 20,
-      marginBottom: 20,
-
-   },
-
-   grid: {
-      flexDirection: "row",
-      flexWrap: "wrap",
-      justifyContent: "space-between",
-      marginBottom: 24,
-
-   },
-
-
-   techItem: {
-      width: "30%",
-      alignItems: "center",
-      marginBottom: 30,
-
-
-   },
-
-   toolLable: {
-
-      fontSize: 12,
-      color: "#888",
-      marginBottom: 6,
-      alignContent: "center",
-
-
-   },
-
-   toolName: {
-      fontSize: 15,
-      fontWeight: "600",
-      textAlign: "center",
-      color: "#111",
-
-
-   },
-
-   tech: {
-
-
-      marginBottom: 15,
-      textAlign: "center",
-
-   },
-
-
-   imageBox: {
-      height: 150,
-      backgroundColor: "#ccc",
-      justifyContent: "center",
-      alignItems: "center",
-      marginTop: 15,
-
-
-
-   },
-
+  sectionContainer: {
+    width: 708,
+    height: 473,
+    backgroundColor: '#717171',
+    borderWidth: 1,
+    borderColor: '#F2F2F2',
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 4,
+    paddingVertical: 16,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+  },
+  heading: {
+    width: 296,
+    height: 38,
+    color: '#FAFAFA',
+    fontFamily: 'Roboto',
+    fontSize: 32,
+    fontWeight: '700',
+    lineHeight: 32,
+    textAlign: 'center',
+    textAlignVertical: 'center',
+  },
+  icon: {
+    marginVertical: 4,
+  },
+  bodyText: {
+    width: 265,
+    height: 162,
+    color: '#FAFAFA',
+    fontFamily: 'Inter',
+    fontSize: 20,
+    fontWeight: '500',
+    lineHeight: 20,
+    textAlign: 'center',
+    textAlignVertical: 'center',
+  },
+  button: {
+    width: 245,
+    height: 35,
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#F2F2F2',
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 17,
+  },
+  buttonPressed: {
+    opacity: 0.85,
+  },
+  buttonLabel: {
+    color: '#FDFDFD',
+    fontFamily: 'Roboto',
+    fontSize: 24,
+    fontWeight: '600',
+    lineHeight: 24,
+    textAlign: 'center',
+  },
 });
-
-
-

--- a/src/stories/InformationalComponent.stories.tsx
+++ b/src/stories/InformationalComponent.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { View } from 'react-native';
+import { fn } from 'storybook/test';
+
+import InformationalComponent from '../components/InformationalComponent';
+
+const meta = {
+  title: 'Components/InformationalComponent',
+  component: InformationalComponent,
+  decorators: [
+    (Story) => (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 24,
+          backgroundColor: '#E5E5E5',
+        }}
+      >
+        <Story />
+      </View>
+    ),
+  ],
+  tags: ['autodocs'],
+  args: {
+    onPress: fn(),
+  },
+} satisfies Meta<typeof InformationalComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/InformationalComponent.stories.tsx
+++ b/src/stories/InformationalComponent.stories.tsx
@@ -25,6 +25,12 @@ const meta = {
   ],
   tags: ['autodocs'],
   args: {
+    title: 'The Design Process',
+    iconName: 'design-services',
+    textSections: [
+      'Find out how the App Development program do for you.',
+      'Grow your business or non-profit for free.',
+    ],
     onPress: fn(),
   },
 } satisfies Meta<typeof InformationalComponent>;


### PR DESCRIPTION
## Summary & Changes 📃

* **Resolves:** #109 

* **Summary:**

  * 🔨 This issue adds a reusable informational section for the Home mobile view.
  * 👀 The expected behavior is a centered section with heading, icon, text, and a CTA button that matches the design.
  * 🗨️ I focused on keeping the component reusable and added a Storybook story so it can be tested independently.

* **Changes:**

  * ✅ Refactored `InformationalComponent` to match “The Design Process” section
  * ✅ Added heading, icon, body text, and CTA button
  * ✅ Used existing `MaterialIcons` instead of adding new dependencies
  * ✅ Added a new Storybook story file for this component
  * 📝 Kept all changes scoped to only the component and story file

## Screenshots / Visual Aids 🔎

<sub><i>📌 Required for UI changes</i></sub>

<details>
  <summary> Expand ⬇️ </summary>

### After
<img width="600" height="400" alt="InformationalComponent" src="https://github.com/user-attachments/assets/8309467d-5ed3-4a91-951c-7cf69dbf4ad0" />

</details>

## How to Test 🧪

1. Run the project
2. Run Storybook:

   * `npm run storybook`
3. Open:

   * `Components/InformationalComponent`
4. Verify:

   * Heading shows “The Design Process”
   * Icon is centered
   * Body text matches design
   * Button shows “See more details”
   * No other components are affected

## Checklist ✅

* [x] I have tested this locally and it works as expected
* [x] This PR resolves an issue (`Resolves #109`)
* [x] Reviewers, assignees, and labels are correctly assigned
* [x] Changes are scoped only to this issue

ℹ️ The previous content inside `InformationalComponent` was not used anywhere in the app, so it was safely replaced with the new section required for this issue.