### PR TITLE
nsc-dev-expo-site_6_127_feat-stat-blocks

### DIFF
--- a/src/components/StatBlock.stories.tsx
+++ b/src/components/StatBlock.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { Meta, StoryObj } from '@storybook/react';
+import StatBlock from './StatBlock';
+
+const meta = {
+    title: 'Components/StatBlock',
+    component: StatBlock,
+    parameters: {
+        layout: 'fullscreen', 
+    },
+    argTypes: {
+        value: { control: 'text' },
+        description: { control: 'text' },
+    },
+} satisfies Meta<typeof StatBlock>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const gradStats = [
+    {
+        id: '1',
+        value: '80%',
+        description: 'of students\nfind gainful employment',
+    },
+    {
+        id: '2',
+        value: '40%',
+        description: 'of students\ngo on to masters degrees',
+    },
+    {
+        id: '3',
+        value: '100+',
+        description: 'students have graduated',
+    }
+];
+
+export const Normal: Story = {
+    args: {
+        value: '', 
+        description: '',
+    },
+    render: () => (
+        <View style={{ flex: 1, backgroundColor: '#ffffff', paddingVertical: 40, width: '100%', alignItems: 'center' }}>
+            {gradStats.map((stat) => (
+                <StatBlock 
+                    key={stat.id} 
+                    value={stat.value} 
+                    description={stat.description} 
+                    style={{ width: 320, height: 180 }} 
+                />
+            ))}
+        </View>
+    ),
+};

--- a/src/components/StatBlock.tsx
+++ b/src/components/StatBlock.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet, View, Text, ViewStyle } from 'react-native';
+
+export interface StatBlockProps {
+    value: string;
+    description: string;
+    style?: ViewStyle;
+}
+
+function renderStatValue(value: string) {
+    const lastChar = value[value.length - 1];
+    
+    if (lastChar === '%' || lastChar === '+') {
+        return (
+            <Text style={styles.statValue}>
+                {value.slice(0, -1)}
+                <Text style={styles.specialCharacter}>{lastChar}</Text>
+            </Text>
+        );
+    }
+    
+    return <Text style={styles.statValue}>{value}</Text>;
+}
+
+export default function StatBlock({ value, description, style }: StatBlockProps) {
+    return (
+        <View style={[styles.cardContainer, style]}>
+            {renderStatValue(value)}
+            <Text style={styles.descriptionText}>{description}</Text>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    cardContainer: {
+        backgroundColor: '#4A4A4A',
+        paddingTop: 20,
+        paddingHorizontal: 24,
+        marginVertical: 20, 
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        elevation: 5, 
+    },
+    statValue: {
+        fontSize: 64,
+        fontWeight: 'bold',
+        color: '#FFFFFF',
+        textAlign: 'center',
+        fontFamily: 'Inter',
+    },
+    specialCharacter: {
+        fontSize: 48,
+        color: '#FFFFFF',
+    },
+    descriptionText: {
+        fontSize: 16,
+        color: '#d0d0d0',
+        textAlign: 'center',
+        marginTop: -1, 
+        lineHeight: 22, 
+        fontFamily: 'Inter',
+    },
+});

--- a/src/stories/StatBlock.stories.tsx
+++ b/src/stories/StatBlock.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 import type { Meta, StoryObj } from '@storybook/react';
-import StatBlock from './StatBlock';
+import StatBlock from '../components/StatBlock';
 
 const meta = {
     title: 'Components/StatBlock',


### PR DESCRIPTION
…#127)


<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** `#127`

- **Summary:** (Briefly describe what this PR does)
  - 🔨 What does this issue fix?
  Fulfills the feature request for "Stats Blocks - Client Engagement Framework (mobile) v2" by creating a new, modular component based on Figma designs.

  - 👀 What is the expected behavior?
Displays a vertically stacked, mobile-responsive set of 3 Stat Blocks. The component relies on dynamic data arrays to populate the blocks, making it highly reusable across the app.

  - 🗨️ Any relevant technical details?
  
 Refactored the renderStatValue formatting logic out of the legacy IndustryStats.tsx component to create a standalone "dumb" component. Implemented pixel-perfect styling using fixed dimensions (320x180), customized translateY values for special characters, and negative margins for exact text alignment.

- **Changes:**
  - Created StatBlock.tsx and StatBlock.stories.tsx to build and document the component.
  - Implemented interactive Storybook controls and a Normal story that renders the full mobile stack.
  - No breaking changes. IndustryStats.tsx remains untouched to prevent regressions while we transition to this new modular component.
  - By separating the UI rendering (StatBlock) from the data mapping, this component can now be easily deployed on the Home, About, or Admissions pages without rewriting logic.


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>
<img width="2544" height="1268" alt="StatBlock" src="https://github.com/user-attachments/assets/c953bb70-abe1-4fe3-a359-4e4fcca1bcaa" />
</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Fetch and checkout the branch feature/127-stats-blocks
   - Step 2: Open the terminal and run npm run storybook
   - Step 3: Open Storybook in your browser and navigate to Components -> StatBlock -> Normal
2. **Expected Behavior: The browser should display the three Stat Blocks stacked vertically, perfectly matching the provided Figma design (dark gray background, drop shadow, heavy 900 font weight, adjusted percentage/plus signs).


## Checklist ✅

- [X ] I have **tested** this PR **locally** and it works as expected.
- [X ] This PR **resolves an issue** (`Resolves #127`).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ X] **Squash commits** and enable **auto-merge** if approved.

