### PR TITLE
Feature/#107project image grid   home mobile v2

### DIFF
--- a/src/components/BrandCard.tsx
+++ b/src/components/BrandCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+// Define the shape of the data this component expects
+interface BrandCardProps {
+  title: string;
+  IconComponent: React.ComponentType<{ width: number; height: number; fill?: string }>;
+}
+
+export const BrandCard = ({ title, IconComponent }: BrandCardProps) => {
+  return (
+    <View style={styles.cardContainer}>
+      <Text style={styles.labelText}>Icon of brand*</Text>
+      {/* Brand Icon Placeholder */}
+
+       {/* Brand Title Text */}
+      <Text style={styles.titleText}>{title}</Text>
+    </View>
+    );
+};
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    width: 160,
+  },
+  iconWrapper: {
+    marginBottom: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  titleText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    textAlign: 'center',
+    fontWeight: '400',
+  },
+  labelText: {
+    color: '#A0A0A0',       // Muted gray to match the secondary look in Figma
+    fontSize: 12,           // Smaller font size for sub-labels
+    marginBottom: 6,        // Space between the label and the icon below it
+    textAlign: 'center',
+  },
+});

--- a/src/components/BrandCard.tsx
+++ b/src/components/BrandCard.tsx
@@ -23,24 +23,26 @@ const styles = StyleSheet.create({
   cardContainer: {
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 16,
-    width: 160,
+    paddingVertical: 24,
+    paddingHorizontal: 16,
+    width: '100%',
   },
   iconWrapper: {
-    marginBottom: 8,
+    marginBottom: 4,
     alignItems: 'center',
     justifyContent: 'center',
   },
   titleText: {
-    color: '#FFFFFF',
-    fontSize: 16,
+    color: '#D9D9D9',
+    fontSize: 32,
     textAlign: 'center',
     fontWeight: '400',
+    lineHeight: 38,
   },
   labelText: {
-    color: '#A0A0A0',       // Muted gray to match the secondary look in Figma
-    fontSize: 12,           // Smaller font size for sub-labels
-    marginBottom: 6,        // Space between the label and the icon below it
+    color: '#D9D9D9',       // Muted gray to match the secondary look in Figma
+    fontSize: 14,           // Smaller font size for sub-labels
     textAlign: 'center',
+    fontWeight: '400',
   },
 });

--- a/src/components/BrandGrid.tsx
+++ b/src/components/BrandGrid.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { BrandCard } from './BrandCard';
+
+// Shape for the array of brand items
+interface BrandItem {
+  id: string;
+  title: string;
+  IconComponent: React.ComponentType<{ width: number; height: number; fill?: string }>;
+}
+
+interface BrandGridProps {
+  brands: BrandItem[];
+}
+
+export const BrandGrid = ({ brands }: BrandGridProps) => {
+  return (
+    <View style={styles.gridContainer}>
+      {brands.map((item) => (
+        <View key={item.id} style={styles.gridItem}>
+          <BrandCard title={item.title} IconComponent={item.IconComponent} />
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  gridContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignItems: 'center',
+    maxWidth: 400, // Keeps the grid compact like the Figma screenshot
+  },
+  gridItem: {
+    width: '50%', // Splitting into a 2-column layout
+    alignItems: 'center',
+    marginVertical: 12,
+  },
+});

--- a/src/components/BrandGrid.tsx
+++ b/src/components/BrandGrid.tsx
@@ -31,11 +31,12 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'center',
     alignItems: 'center',
-    maxWidth: 400, // Keeps the grid compact like the Figma screenshot
+    maxWidth: 800, // Keeps the grid compact like the Figma screenshot
+    lineHeight: 38, 
   },
   gridItem: {
     width: '50%', // Splitting into a 2-column layout
     alignItems: 'center',
-    marginVertical: 12,
+    marginVertical: 24,
   },
 });

--- a/src/components/BrandGrid.tsx
+++ b/src/components/BrandGrid.tsx
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'center',
     alignItems: 'center',
-    maxWidth: 800, // Keeps the grid compact like the Figma screenshot
+    maxWidth: 800,
     lineHeight: 38, 
   },
   gridItem: {

--- a/src/stories/BrandCard.stories.tsx
+++ b/src/stories/BrandCard.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { BrandCard } from '../components/BrandCard'; 
+import { BrandGrid } from '../components/BrandGrid'; 
+
+export default {
+  title: 'Components/BrandCard',
+  component: BrandCard,
+  decorators: [
+    (Story: React.ComponentType) => (
+      <View style={styles.container}>
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+// A simple, minimalist SVG placeholder icon for testing
+const SampleIcon = (props: { width: number; height: number; fill?: string }) => (
+  <View 
+    style={{ 
+      width: props.width, 
+      height: props.height, 
+      backgroundColor: props.fill || '#fff', 
+      borderRadius: 4 
+    }} 
+  />
+);
+
+// First "Story" case
+export const GirlGeekCon = () => (
+  <BrandCard title="Girl Geek Con" IconComponent={SampleIcon} />
+);
+
+// Second case 
+export const PelletierConstruction = () => (
+  <BrandCard title="Pelletier Construction" IconComponent={SampleIcon} />
+);
+
+// --- Full Grid Story ---
+const mockBrands = [
+  { id: '1', title: 'Girl Geek Con', IconComponent: SampleIcon },
+  { id: '2', title: "Belinda's Closet", IconComponent: SampleIcon },
+  { id: '3', title: 'NSC Events', IconComponent: SampleIcon },
+  { id: '4', title: 'Pelletier Construction', IconComponent: SampleIcon },
+];
+
+export const FullBrandGrid = () => (
+  <BrandGrid brands={mockBrands} />
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1A1A1A', // Matching the dark theme from your Figma image
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+});

--- a/src/stories/BrandCard.stories.tsx
+++ b/src/stories/BrandCard.stories.tsx
@@ -55,6 +55,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#1A1A1A', // Matching the dark theme from your Figma image
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 24,
+    padding: 8,
   },
 });


### PR DESCRIPTION
<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** #107

- **Summary:** This PR aims to recreate the image grid Figma elements from the "Partnered” section of the NSC Dev Expo home mobile page to Storybook UI
- 🔨 What does this issue fix?
    - **In components folder**:
         -   _BrandCard.tsx:_ Container for the image grid 
         -   _BrandGird.tsx_: Renders the 2x2 image grid 
    - **In the stories folder**: 
         - _BrandCard.stories.tsx_: Storybook UI integration for image grid  

  - 👀 _What is the expected behavior?_ When launching Storybook, there should be a "BrandCard" component with three stories:  
         - Girl Geek Con and Pelletier Construction. Renders individual image grid groups that can be used to experiment with properties involving the BrandCard stylesheet. 
         - Full Brand Grid. As the name implies, it's the full image grid recreation. 
  - 🗨️ Any relevant technical details?
         - IconComponent prop doesn’t get used to match the Figma recreation, but would be an ideal placeholder and can be easily added to the container if desired.   
         - Can add/remove items on the image grid by configuring the mockBrands prop.  

- **Changes:**
  -  ✅ Added src\components\BrandCard.tsx
  - ✅ Added src\stories\BrandCard.stories.tsx
  - ✅ Added src\components\BrandGrid.tsx

  - 🔗 Related Issue: #107
  


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>
   
   **Figma:** 
<img width="700" height="588" alt="partnered section" src="https://github.com/user-attachments/assets/d193a4e0-8983-4a9d-9234-52cd5d350ea6" />

  **Storybook UI (Mobile Width):** 
<img width="500" height="465" alt="image" src="https://github.com/user-attachments/assets/141c89b2-6d25-4260-9df8-f51cc2390939" />

</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Pull Branch: feature/#107project-image-grid---home-mobile-v2 
   - Step 2: Type in terminal: npm run storybook 
   - Step 3: When Storybook launches, follow the Local URL in your preferred browser (http://localhost:6006/), then shrink the browser to minimum width (for mobile resolution)
   - Step 4: Go to Components > BrandCard > Full Brand Grid and compare to the Figma image



## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #107).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [X] **Squash commits** and enable **auto-merge** if approved.

